### PR TITLE
Fix issue of Editor requiring Auth headers to call APIs

### DIFF
--- a/modules/distribution/carbon-home/conf/server/deployment.yaml
+++ b/modules/distribution/carbon-home/conf/server/deployment.yaml
@@ -361,3 +361,7 @@ auth.configs:
          role:
            id: 1
            displayName: admin
+  restAPIAuthConfigs:
+    exclude:
+      - /simulation/*
+      - /stores/*


### PR DESCRIPTION
## Purpose
resolves wso2/carbon-analytics#1720

This PR will suppress the requiring AuthHeaders for the simulation and store APIs
