### PR TITLE
Add support for Java 11

### DIFF
--- a/modules/distribution/carbon-home/bin/ciphertool.bat
+++ b/modules/distribution/carbon-home/bin/ciphertool.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
+goto jdk16
+
+:jdk16
+goto runTool
+
+rem ----------------- Execute The Requested Command ----------------------------
+:runTool
+cd %CARBON_HOME%
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+
+set CMD_LINE_ARGS= -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%"
+java -cp "\bin\tools\*" -Dcarbon.home="%CARBON_HOME%" org.wso2.carbon.secvault.ciphertool.CipherToolInitializer %*
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/modules/distribution/carbon-home/bin/ciphertool.sh
+++ b/modules/distribution/carbon-home/bin/ciphertool.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   exit 1
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+cd "$CARBON_HOME";
+
+$JAVACMD \
+    -Dcarbon.home="$CARBON_HOME" \
+    -cp "bin/tools/*" org.wso2.carbon.secvault.ciphertool.CipherToolInitializer $*

--- a/modules/distribution/carbon-home/bin/icf-provider.bat
+++ b/modules/distribution/carbon-home/bin/icf-provider.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+
+set CURRENT_DIR=%cd%
+
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME" -Dwso2.carbon.tool="icf-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/modules/distribution/carbon-home/bin/icf-provider.sh
+++ b/modules/distribution/carbon-home/bin/icf-provider.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO7 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+# get the current directory from which the script is executed
+CURRENT_DIR=${PWD};
+
+cd "$CARBON_HOME/bin/";
+java -cp "../bin/tools/*" -Dcarbon.home="$CARBON_HOME" -Dwso2.carbon.tool="icf-provider" org.wso2.carbon.tools.CarbonToolExecutor $1 $2 $3 $4

--- a/modules/distribution/carbon-home/bin/jartobundle.bat
+++ b/modules/distribution/carbon-home/bin/jartobundle.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+
+set CURRENT_DIR=%cd%
+
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*" -Dwso2.carbon.tool="jar-to-bundle-converter" org.wso2.carbon.tools.CarbonToolExecutor "%1" "%2" "%CURRENT_DIR%"
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/modules/distribution/carbon-home/bin/jartobundle.sh
+++ b/modules/distribution/carbon-home/bin/jartobundle.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+# get the current directory from which the script is executed
+CURRENT_DIR=${PWD};
+
+cd "$CARBON_HOME/bin/";
+java -cp "../bin/tools/*" -Dwso2.carbon.tool="jar-to-bundle-converter" org.wso2.carbon.tools.CarbonToolExecutor "$1" "$2" "$CURRENT_DIR"

--- a/modules/distribution/carbon-home/bin/osgi-lib.bat
+++ b/modules/distribution/carbon-home/bin/osgi-lib.bat
@@ -1,0 +1,78 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*;..\bin\bootstrap\*" -Dwso2.carbon.tool="osgi-lib-deployer" org.wso2.carbon.tools.CarbonToolExecutor "%1" "%CARBON_HOME%"
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/modules/distribution/carbon-home/bin/osgi-lib.sh
+++ b/modules/distribution/carbon-home/bin/osgi-lib.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+cd "$CARBON_HOME/bin/";
+
+java -cp "../bin/tools/*:../bin/bootstrap/*" -Dwso2.carbon.tool="osgi-lib-deployer" org.wso2.carbon.tools.CarbonToolExecutor "$1" "$CARBON_HOME"

--- a/modules/distribution/carbon-home/runtime/server/carbon.bat
+++ b/modules/distribution/carbon-home/runtime/server/carbon.bat
@@ -146,13 +146,13 @@ rem find the version of the jdk
 set CMD=RUN %*
 
 :checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8] 11.[0]" >NUL
 IF ERRORLEVEL 1 goto unknownJdk
 goto jdk16
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8
+echo [ERROR] CARBON is supported only on JDK 1.8 and 11
 goto jdk16
 
 :jdk16
@@ -167,9 +167,16 @@ rem ---------- Add jars to classpath ----------------
 
 set CARBON_CLASSPATH="%CARBON_HOME%\bin\bootstrap\*";%CARBON_CLASSPATH%
 
+PATH %PATH%;%JAVA_HOME%\bin\
+for /f tokens^=2-5^ delims^=.-_^" %%j in ('java -fullversion 2^>^&1') do set "jver=%%j%%k%%l%%m"
+
+set JAVA_VER_BASED_OPTS
+
 set JAVA_ENDORSED="%CARBON_HOME%\bin\bootstrap\endorsed";"%JAVA_HOME%\jre\lib\endorsed";"%JAVA_HOME%\lib\endorsed"
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8 -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
+if %jver% LSS 11000 set JAVA_VER_BASED_OPTS="-Djava.endorsed.dirs=%JAVA_ENDORSED_DIRS%"
+
+set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% %JAVA_VER_BASED_OPTS% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8  -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
 
 :runJava
 echo JAVA_HOME environment variable is set to %JAVA_HOME%

--- a/modules/distribution/src/policies/pages/cookie-policy.hbs
+++ b/modules/distribution/src/policies/pages/cookie-policy.hbs
@@ -34,7 +34,7 @@
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">WSO2
-                                                                         Streaming Integrator Tooling (referred to as “WSO2 SP
+                                                                         Streaming Integrator Tooling (referred to as “WSO2 SI
                                                                          ” within this
                                                                          policy) is an open source stream processing
                                                                          application that is based
@@ -47,7 +47,7 @@
                                                                             Policy</b></font></font></h2>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
                                                                           uses cookies so that it can provide the
                                                                          best user experience
                                                                          for you and identify you for security purposes.
@@ -58,12 +58,12 @@
             style="margin-top: 0.21in; margin-bottom: 0.11in; border: none; padding: 0in; line-height: 110%; orphans: 0; widows: 0">
             <a name="h.2cmh0sute7p7"></a>
             <font color="#333333"><font size="6" style="font-size: 22pt">How does
-                                                                         WSO2 SP 4.2.0 process cookies?</font></font>
+                                                                         WSO2 SI 1.0.0 process cookies?</font></font>
         </h2>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 stores and retrieves information on your
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 stores and retrieves information on your
                                                                          browser using cookies.
                                                                          Some cookies allow a user to log in to the
                                                                          system and maintain
@@ -81,9 +81,9 @@
                 size="2" style="font-size: 10pt"><u><a
                 href="{{@contextPath}}/privacy-policy">WSO</a><a
                 href="{{@contextPath}}/privacy-policy">2
-        </a><a href="{{@contextPath}}/privacy-policy">SP</a><a
+        </a><a href="{{@contextPath}}/privacy-policy">SI</a><a
                 href="{{@contextPath}}/privacy-policy">
-            4.2.0 </a><a href="{{@contextPath}}/privacy-policy">Privacy</a><a
+            1.0.0 </a><a href="{{@contextPath}}/privacy-policy">Privacy</a><a
                 href="{{@contextPath}}/privacy-policy">
         </a><a href="{{@contextPath}}/privacy-policy">Policy</a><a
                 href="{{@contextPath}}/privacy-policy">.</a></u></font></font></p>
@@ -109,13 +109,13 @@
             style="margin-top: 0.21in; margin-bottom: 0.11in; border: none; padding: 0in; line-height: 110%; orphans: 0; widows: 0">
             <a name="h.zhks2mdz1gs3"></a>
             <font color="#333333"><font size="6" style="font-size: 22pt">What
-                                                                         does WSO2 SP 4.2.0 use cookies
+                                                                         does WSO2 SI 1.0.0 use cookies
                                                                          for?</font></font></h2>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">Cookies
-                                                                         are used in two main ways in WSO2 SP
-                                                                         4.2.0.</font></font></p>
+                                                                         are used in two main ways in WSO2 SI
+                                                                         1.0.0.</font></font></p>
         <ol>
             <li />
             <p class="western" align="left"
@@ -132,8 +132,8 @@
         </ol>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 uses cookies for the following purposes
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 uses cookies for the following purposes
                                                                          listed below:</font></font></p>
         <h3 class="western" align="left"
             style="margin-top: 0.21in; margin-bottom: 0.11in; border: none; padding: 0in; line-height: 110%; orphans: 0; widows: 0">
@@ -141,8 +141,8 @@
             <font color="#333333"><font size="5" style="font-size: 18pt">Preferences</font></font></h3>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 uses these cookies to remember your
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 uses these cookies to remember your
                                                                          settings and preferences,
                                                                          and to auto-fill the form fields to make your
                                                                          interactions with the
@@ -160,10 +160,10 @@
             <li />
             <p class="western" align="left"
                style="margin-bottom: 0in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-                <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                             4.2.0 uses selected cookies to identify and
+                <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                             1.0.0 uses selected cookies to identify and
                                                                              prevent security risks.
-                                                                             For example, WSO2 SP 4.2.0 may use these
+                                                                             For example, WSO2 SI 1.0.0 may use these
                                                                              cookies to store your
                                                                              session information in order to prevent
                                                                              others from changing your
@@ -175,8 +175,8 @@
             <li />
             <p class="western" align="left"
                style="margin-bottom: 0in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-                <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                             4.2.0 uses session cookies to maintain your
+                <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                             1.0.0 uses session cookies to maintain your
                                                                              active session.</font></font><br />
                 <br />
 
@@ -188,8 +188,8 @@
             <font color="#333333"><font size="5" style="font-size: 18pt">Performance</font></font></h3>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 may use cookies to allow “Remember Me”
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 may use cookies to allow “Remember Me”
                                                                          functionalities.</font></font></p>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; font-weight: normal; line-height: 115%; orphans: 2; widows: 2">
@@ -205,9 +205,9 @@
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">Using
-                                                                         WSO2 SP 4.2.0 may cause some third-party
+                                                                         WSO2 SI 1.0.0 may cause some third-party
                                                                          cookies to be set in your
-                                                                         browser. WSO2 SP 4.2.0 has no control over how
+                                                                         browser. WSO2 SI 1.0.0 has no control over how
                                                                          any of them operate.
                                                                          WSO2 strongly advises you to refer the
                                                                          respective cookie policy of
@@ -218,22 +218,22 @@
             style="margin-top: 0.21in; margin-bottom: 0.11in; border: none; padding: 0in; line-height: 110%; orphans: 0; widows: 0">
             <a name="h.xqlxw7fo089z"></a>
             <font color="#333333"><font size="6" style="font-size: 22pt">What
-                                                                         type of cookies does WSO2 SP 4.2.0 use?</font></font>
+                                                                         type of cookies does WSO2 SI 1.0.0 use?</font></font>
         </h2>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 uses persistent cookies and session
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 uses persistent cookies and session
                                                                          cookies. A persistent
-                                                                         cookie helps WSO2 SP 4.2.0 to recognize you as
+                                                                         cookie helps WSO2 SI 1.0.0 to recognize you as
                                                                          an existing user so
                                                                          that it is easier to return to WSO2 or interact
-                                                                         with WSO2 SP 4.2.0
+                                                                         with WSO2 SI 1.0.0
                                                                          without signing in again. After you sign in, a
                                                                          persistent cookie
                                                                          stays in your browser and will be read by WSO2
-                                                                         SP 4.2.0 when you
-                                                                         return to WSO2 SP 4.2.0.</font></font></p>
+                                                                         SI 1.0.0 when you
+                                                                         return to WSO2 SI 1.0.0.</font></font></p>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">A
@@ -252,7 +252,7 @@
                                                                          the cookies used?</font></font></h2>
         <p class="western" align="left"
            style="margin-bottom: 0in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            The following are the main types of cookies used by WSO2 SP 4.2.0</p>
+            The following are the main types of cookies used by WSO2 SI 1.0.0</p>
         <p class="western" align="left"
            style="margin-bottom: 0in; border: none; padding: 0in; font-weight: normal; line-height: 115%; orphans: 2; widows: 2">
             <br />
@@ -523,7 +523,7 @@ cookies are used:</span></font></p>
                                                                          likely, disabling cookies will make you unable
                                                                          to use authentication
                                                                          and authorization functionalities offered by
-                                                                         WSO2 SP 4.2.0.</font></font></p>
+                                                                         WSO2 SI 1.0.0.</font></font></p>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">If you
@@ -531,7 +531,7 @@ cookies are used:</span></font></p>
                                                                          use of cookies, please
                                                                          contact the entity or individuals (or their
                                                                          data protection officer,
-                                                                         if applicable) running this WSO2 SP 4.2.0
+                                                                         if applicable) running this WSO2 SI 1.0.0
                                                                          instance.</font></font></p>
         <h2 class="western" align="left"
             style="margin-top: 0.21in; margin-bottom: 0.11in; border: none; padding: 0in; line-height: 110%; orphans: 0; widows: 0">
@@ -542,11 +542,11 @@ cookies are used:</span></font></p>
             <font color="#333333"><font size="2" style="font-size: 10pt">This
                                                                          cookie policy is only for illustrative purposes
                                                                          of the product WSO2
-                                                                         SP 4.2.0. The content in the policy is
+                                                                         SI 1.0.0. The content in the policy is
                                                                          technically correct at the
                                                                          time of the product shipment. The organization
                                                                          which runs this WSO2
-                                                                         SP 4.2.0 instance has full authority and
+                                                                         SI 1.0.0 instance has full authority and
                                                                          responsibility with regard
                                                                          to the effective Cookie Policy. WSO2, its
                                                                          employees, partners, and
@@ -554,10 +554,10 @@ cookies are used:</span></font></p>
                                                                          require, store, process
                                                                          or control any of the data, including personal
                                                                          data contained in WSO2
-                                                                         ISP 4.2.0. All data, including personal data is
+                                                                         ISI 1.0.0. All data, including personal data is
                                                                          controlled and
                                                                          processed by the entity or individual running
-                                                                         WSO2 SP 4.2.0. WSO2,
+                                                                         WSO2 SI 1.0.0. WSO2,
                                                                          its employees partners and affiliates are not a
                                                                          data processor or a
                                                                          data controller within the meaning of any data
@@ -566,7 +566,7 @@ cookies are used:</span></font></p>
                                                                          undertake any responsibility
                                                                          or liability in connection with the lawfulness
                                                                          or the manner and
-                                                                         purposes for which WSO2 SP 4.2.0 is used by
+                                                                         purposes for which WSO2 SI 1.0.0 is used by
                                                                          such entities or persons.
             </font></font>
         </p>

--- a/modules/distribution/src/policies/pages/privacy-policy.hbs
+++ b/modules/distribution/src/policies/pages/privacy-policy.hbs
@@ -45,7 +45,7 @@
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">This
-                                                                         policy describes how WSO2 SP 4.2.0 captures
+                                                                         policy describes how WSO2 SI 1.0.0 captures
                                                                          your personal
                                                                          information, the purposes of collection, and
                                                                          information about the
@@ -58,13 +58,13 @@
                                                                          and is applicable for
                                                                          the software as a product. WSO2 Inc. and its
                                                                          developers have no
-                                                                         access to the information held within WSO2 SP
-                                                                         4.2.0. Please see the
+                                                                         access to the information held within WSO2 SI
+                                                                         1.0.0. Please see the
             </font></font><a href="#disclaimer"><font
                 color="#337ab7"><font size="2" style="font-size: 10pt"><u>Disclaimer</u></font></font></a><font
                 color="#333333"><font size="2" style="font-size: 10pt">
             section for more information. Entities, organisations or individuals
-            controlling the use and administration of WSO2 SP 4.2.0 should create
+            controlling the use and administration of WSO2 SI 1.0.0 should create
             their own privacy policies setting out the manner in which data is
             controlled or processed by the respective entity, organisation or
             individual.</font></font></p>
@@ -75,8 +75,8 @@
                                                                          personal information?</font></font></h2>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 considers anything related to you and by
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 considers anything related to you and by
                                                                          which you may be
                                                                          identified as your personal information. This
                                                                          includes, but is not
@@ -116,22 +116,22 @@
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="6" style="font-size: 22pt">How does
-                                                                         WSO2 SP 4.2.0 collect personal
+                                                                         WSO2 SI 1.0.0 collect personal
                                                                          information?</font></font></p>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 collects your login details to serve your
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 collects your login details to serve your
                                                                          access requirements. </font></font>
         </p>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">In
-                                                                         addition, the information sent to WSO2 SP 4.2.0
+                                                                         addition, the information sent to WSO2 SI 1.0.0
                                                                          by your organization
                                                                          to be processed may include personal
                                                                          information. This information is not retained unless
-                                                                         WSO2 SP 4.2.0 is
+                                                                         WSO2 SI 1.0.0 is
                                                                          specifically configured by server
                                                                          administrators to store that
                                                                          information in databases based on the client
@@ -145,13 +145,13 @@
                                                                          processing include personal
                                                                          information, and if it does, to use the data
                                                                          obfuscation/removal
-                                                                         methods supported by WSO2 SP 4.2.0 to
+                                                                         methods supported by WSO2 SI 1.0.0 to
                                                                          hide/delete that information
                                                                          once it is processed.</font></font></p>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 also records the time of the day you
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 also records the time of the day you
                                                                          logged in (year, month,
                                                                          week, hour or minute) for the purpose of
                                                                          processing the streaming
@@ -164,8 +164,8 @@
                                                                          Technologies</font></font></h3>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 collects your information
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 collects your information
                                                                          by:</font></font></p>
         <ul>
             <li />
@@ -194,8 +194,8 @@
                                                                          personal information</font></font></h2>
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
-            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SP
-                                                                         4.2.0 uses the following personal information
+            <font color="#333333"><font size="2" style="font-size: 10pt">WSO2 SI
+                                                                         1.0.0 uses the following personal information
                                                                          only to protect your
                                                                          account from unauthorized access or potential
                                                                          hacking attempts.:</font></font></p>
@@ -230,8 +230,8 @@
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">Please
                                                                          note that the organisation, entity or
-                                                                         individual running WSO2 SP
-                                                                         4.2.0 may be compelled to disclose your
+                                                                         individual running WSO2 SI
+                                                                         1.0.0 may be compelled to disclose your
                                                                          personal information with or
                                                                          without your consent when it is required by law
                                                                          following due and
@@ -243,9 +243,9 @@
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">If you,
-                                                                         as a user of WSO2 SP 4.2.0 submit personal
+                                                                         as a user of WSO2 SI 1.0.0 submit personal
                                                                          information relating to
-                                                                         yourself or another party to WSO2 SP 4.2.0, you
+                                                                         yourself or another party to WSO2 SI 1.0.0, you
                                                                          can use the data
                                                                          removal/obfuscation features supported by the
                                                                          product to hide/remove
@@ -253,8 +253,8 @@
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">If your
-                                                                         personal information is submitted to WSO2 SP
-                                                                         4.2.0 by your
+                                                                         personal information is submitted to WSO2 SI
+                                                                         1.0.0 by your
                                                                          organization or another third party, request
                                                                          that party to
                                                                          hide/delete that information.</font></font></p>
@@ -271,7 +271,7 @@
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">Upgraded
-                                                                         versions of WSO2 SP 4.2.0 may contain changes
+                                                                         versions of WSO2 SI 1.0.0 may contain changes
                                                                          to this policy and
                                                                          revisions to this policy will be packaged
                                                                          within such upgrades. Such
@@ -286,8 +286,8 @@
         <p class="western" align="left"
            style="margin-bottom: 0.11in; border: none; padding: 0in; line-height: 115%; orphans: 2; widows: 2">
             <font color="#333333"><font size="2" style="font-size: 10pt">If your
-                                                                         data is already published to WSO2 SP
-                                                                         4.2.0 ; you have the
+                                                                         data is already published to WSO2 SI
+                                                                         1.0.0 ; you have the
                                                                          right to deactivate your account if you find
                                                                          that this privacy policy
                                                                          is unacceptable to you.</font></font></p>
@@ -330,11 +330,11 @@
                                                                              not have access to and do
                                                                              not require, store, process or control any
                                                                              of the data, including
-                                                                             personal data contained in WSO2 SP 4.2.0.
+                                                                             personal data contained in WSO2 SI 1.0.0.
                                                                              All data, including
                                                                              personal data is controlled and processed
                                                                              by the entity or
-                                                                             individual running WSO2 SP 4.2.0. WSO2, its
+                                                                             individual running WSO2 SI 1.0.0. WSO2, its
                                                                              employees partners and
                                                                              affiliates are not a data processor or a
                                                                              data controller within the
@@ -344,7 +344,7 @@
                                                                              or liability in
                                                                              connection with the lawfulness or the
                                                                              manner and purposes for which
-                                                                             WSO2 SP 4.2.0 is used by such entities or
+                                                                             WSO2 SI 1.0.0 is used by such entities or
                                                                              persons. </font></font>
             </p>
         </ol>
@@ -353,21 +353,21 @@
             <font color="#333333"><font size="2" style="font-size: 10pt">This
                                                                          privacy policy is for the informational
                                                                          purposes of the entity or
-                                                                         persons running WOS2 SP 4.2.0 and sets out the
+                                                                         persons running WOS2 SI 1.0.0 and sets out the
                                                                          processes and
-                                                                         functionality contained within WSO2 SP 4.2.0
+                                                                         functionality contained within WSO2 SI 1.0.0
                                                                          regarding personal data
                                                                          protection. It is the responsibility of
                                                                          entities and persons running
-                                                                         WSO2 SP 4.2.0 to create and administer its own
+                                                                         WSO2 SI 1.0.0 to create and administer its own
                                                                          rules and processes
                                                                          governing users’ personal data, and such rules
                                                                          and processes may
                                                                          change the use, storage and disclosure policies
                                                                          contained herein.
                                                                          Therefore users should consult the entity or
-                                                                         persons running WSO2 SP
-                                                                         4.2.0 for its own privacy policy for details
+                                                                         persons running WSO2 SI
+                                                                         1.0.0 for its own privacy policy for details
                                                                          governing users’
                                                                          personal data. </font></font>
         </p>


### PR DESCRIPTION
## Purpose
Add support for Java 11

## Release note
Support for Java 11 for Windows environments.

## Test environment
java version "11.0.4" 2019-07-16 LTS
Java(TM) SE Runtime Environment 18.9 (build 11.0.4+10-LTS)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.4+10-LTS, mixed mode)

Windows 10 Pro