### PR TITLE
Fix Checkstyle issues that cause build failure on Windows

### DIFF
--- a/modules/samples/sample-clients/http-client/src/main/java/org/wso2/si/http/client/EventSendingUtil.java
+++ b/modules/samples/sample-clients/http-client/src/main/java/org/wso2/si/http/client/EventSendingUtil.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Event generating util class for http source
+ * Event generating util class for http source.
  */
 public class EventSendingUtil {
     private static final Logger log = Logger.getLogger(EventSendingUtil.class);

--- a/modules/samples/sample-clients/kafka-producer/src/main/java/org/wso2/si/sample/kafka/client/EventSendingUtil.java
+++ b/modules/samples/sample-clients/kafka-producer/src/main/java/org/wso2/si/sample/kafka/client/EventSendingUtil.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Event generating util class for kafka source
+ * Event generating util class for kafka source.
  */
 public class EventSendingUtil {
     private static final Logger log = Logger.getLogger(EventSendingUtil.class);

--- a/modules/samples/sample-clients/mqtt-client/src/main/java/org/wso2/si/mqtt/client/EventSendingUtil.java
+++ b/modules/samples/sample-clients/mqtt-client/src/main/java/org/wso2/si/mqtt/client/EventSendingUtil.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Event generating util class for mqtt source
+ * Event generating util class for mqtt source.
  */
 public class EventSendingUtil {
     private static final Logger log = Logger.getLogger(EventSendingUtil.class);

--- a/modules/samples/sample-clients/rabbitmq-producer/src/main/java/org/wso2/si/sample/rabbitmq/producer/EventSendingUtil.java
+++ b/modules/samples/sample-clients/rabbitmq-producer/src/main/java/org/wso2/si/sample/rabbitmq/producer/EventSendingUtil.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Event generating util class for rabbitmq source
+ * Event generating util class for rabbitmq source.
  */
 public class EventSendingUtil {
     private static final Logger log = Logger.getLogger(EventSendingUtil.class);

--- a/modules/samples/sample-clients/tcp-client/src/main/java/org/wso2/si/tcp/client/EventSendingUtil.java
+++ b/modules/samples/sample-clients/tcp-client/src/main/java/org/wso2/si/tcp/client/EventSendingUtil.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Event generating util class for tcp source
+ * Event generating util class for tcp source.
  */
 public class EventSendingUtil {
     private static final Logger log = Logger.getLogger(EventSendingUtil.class);

--- a/modules/samples/sample-clients/websocket-producer/src/main/java/org/wso2/si/sample/websocket/server/EventSendingUtil.java
+++ b/modules/samples/sample-clients/websocket-producer/src/main/java/org/wso2/si/sample/websocket/server/EventSendingUtil.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Event generating util class for websocket source
+ * Event generating util class for websocket source.
  */
 public class EventSendingUtil {
     private static final Logger log = Logger.getLogger(EventSendingUtil.class);


### PR DESCRIPTION
## Purpose
> Fix _"First sentence should end with a period."_ error caused by Checkstyle. Related issue: https://github.com/wso2/streaming-integrator-tooling/issues/44#issuecomment-545003015

## Test environment
> - Java version: 1.8.0_221
> - Maven version: 3.5.4
> - OS: Windows 10