### PR TITLE
Add jar installation on startup

### DIFF
--- a/modules/distribution/carbon-home/bin/tooling.bat
+++ b/modules/distribution/carbon-home/bin/tooling.bat
@@ -53,6 +53,9 @@ rem find CARBON_HOME if it does not exist due to either an invalid value passed
 rem by the user or the %0 problem on Windows 9x
 if not exist "%CARBON_HOME%\bin\version.txt" goto noServerHome
 
+rem Installing jars
+java -cp ".\*;%CARBON_HOME%\bin\tools\*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "%CARBON_HOME%"
+
 goto startServer
 
 :noServerHome

--- a/modules/distribution/carbon-home/bin/tooling.sh
+++ b/modules/distribution/carbon-home/bin/tooling.sh
@@ -55,6 +55,9 @@ PRGDIR=`dirname "$PRG"`
 
 [ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$PRGDIR/../wso2/server" ; pwd`
 
+# Installing jars
+java -cp "$CARBON_HOME/bin/tools/*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "$CARBON_HOME"
+
 ###########################################################################
 NAME=start-editor
 # Daemon name, where is the actual executable


### PR DESCRIPTION
## Purpose
> With the update of Carbon kernel [[1]](https://github.com/wso2/streaming-integrator-tooling/pull/52/files#diff-600376dffeb79835ede4a0b285078036R920), non-bundle jars in `jars` folder can be converted as bundles, and moved to `lib` folder, when `install-jars` tool is executed. This PR adds necessary commands to call `install-jars` during pack startup (i.e: executing `tooling.sh` or `tooling.bat`).

[1] https://github.com/wso2/streaming-integrator-tooling/pull/52/files#diff-600376dffeb79835ede4a0b285078036R920

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## References
> `sh`: https://github.com/siddhi-io/distribution/blob/master/resources/carbon-home/bin/tooling.sh#L59
> `bat`: https://github.com/siddhi-io/distribution/blob/master/resources/carbon-home/bin/tooling.bat#L57