### PR TITLE
Fix product name with relevance to new update tool

### DIFF
--- a/modules/distribution/src/assembly/filter.properties
+++ b/modules/distribution/src/assembly/filter.properties
@@ -2,4 +2,4 @@ product.name=WSO2 Streaming Integrator Tooling
 product.version=1.1.0
 server.name=WSO2 Carbon Kernel
 server.version=5.2.13
-product.wum.name=wso2-streaming-integrator-tooling
+product.wum.name=wso2si-tooling


### PR DESCRIPTION
## Purpose
to allow new update tool to work without any name conflicts
## Goals
Make name consistent with new update tool

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
