### PR TITLE
Bump dependencies for SI 4.1.0 release

### DIFF
--- a/modules/distribution/carbon-home/LICENSE.txt
+++ b/modules/distribution/carbon-home/LICENSE.txt
@@ -30,7 +30,6 @@ commons-codec-1.4.jar                                                           
 org.wso2.carbon.privacy.forgetme.logs-1.1.21.jar                                                    bundle         apache2
 json-simple-1.1.jar                                                                                 jar            apache2
 HikariCP-2.4.1.jar                                                                                  bundle         apache2
-log4j-1.2.17.jar                                                                                    bundle         apache2
 commons-io-2.4.0.wso2v1.jar                                                                         bundle         apache2
 slf4j-api-1.7.25.jar                                                                                bundle         mit
 org.wso2.carbon.privacy.forgetme.api-1.1.21.jar                                                     bundle         apache2
@@ -42,7 +41,6 @@ org.wso2.carbon.core-5.1.0-alpha2.jar                                           
 commons-cli-1.3.1.jar                                                                               bundle         apache2
 slf4j-log4j12-1.7.25.jar                                                                            bundle         mit
 org.eclipse.equinox.preferences_3.6.0.v20160120-1756.jar                                            bundle         epl1
-com.fasterxml.jackson.dataformat.jackson-dataformat-yaml_2.9.8.jar                                  bundle         apache2
 siddhi-query-api_5.1.19.jar                                                                         bundle         apache2
 org.wso2.carbon.database.query.manager_6.1.48.jar                                                   bundle         apache2
 siddhi-query-compiler_5.1.19.jar                                                                    bundle         apache2
@@ -72,11 +70,8 @@ com.google.gson_2.2.4.jar                                                       
 org.wso2.carbon.streaming.integrator.common_3.0.54.jar                                              bundle         apache2
 generex_1.0.0.wso2v1.jar                                                                            bundle         apache2
 org.apache.ws.commons.axiom.axiom-impl_1.2.20.jar                                                   bundle         apache2
-h2_1.4.199.wso2v1.jar                                                                               bundle         apache2
-h2-1.4.199.jar                                                                                      jarinbundle    apache2
 okhttp_3.8.0.wso2v2.jar                                                                             bundle         apache2
 org.wso2.carbon.editor.log.appender_3.0.54.jar                                                      bundle         apache2
-com.fasterxml.jackson.core.jackson-annotations_2.9.8.jar                                            bundle         apache2
 org.eclipse.osgi.compatibility.state_1.0.200.v20160504-1419.jar                                     bundle         epl1
 org.wso2.carbon.databridge.commons_6.1.50.jar                                                       bundle         apache2
 msf4j-swagger_2.7.7.jar                                                                             bundle         apache2
@@ -95,7 +90,6 @@ io.dropwizard.metrics.jvm_3.2.5.jar                                             
 org.antlr.antlr4-runtime_4.7.2.jar                                                                  bundle         apache2
 fabricator_2.10_2.1.4.wso2v1.jar                                                                    bundle         apache2
 org.wso2.carbon.business.rules.templates.editor.core_3.0.54.jar                                     bundle         apache2
-com.fasterxml.jackson.core.jackson-core_2.9.8.jar                                                   bundle         apache2
 disruptor_3.4.2.wso2v1.jar                                                                          bundle         apache2
 encoder_1.2.0.wso2v2.jar                                                                            bundle         apache2
 org.wso2.carbon.caching_1.1.3.jar                                                                   bundle         apache2
@@ -132,7 +126,6 @@ jaxrs-delegates_2.7.7.jar                                                       
 org.eclipse.equinox.frameworkadmin_2.0.300.v20160504-1450.jar                                       bundle         epl1
 quartz_2.1.1.wso2v1.jar                                                                             bundle         apache2
 org.wso2.carbon.databridge.receiver.thrift_6.1.50.jar                                               bundle         apache2
-com.fasterxml.jackson.core.jackson-databind_2.9.8.jar                                               bundle         apache2
 org.apache.servicemix.bundles.commons-beanutils_1.8.3.2.jar                                         bundle         apache2
 org.apache.ws.commons.axiom.axiom-api_1.2.20.jar                                                    bundle         apache2
 javax.websocket-api_1.1.0.jar                                                                       bundle         cddl1

--- a/pom.xml
+++ b/pom.xml
@@ -469,16 +469,6 @@
                 <version>${msf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${com.fasterxml.jackson.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${com.fasterxml.jackson.core.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-annotations</artifactId>
                 <version>${io.swagger.version}</version>
@@ -487,16 +477,6 @@
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
                 <version>${javax.ws.rs-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-joda</artifactId>
-                <version>${com.fasterxml.jackson.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>${com.fasterxml.jackson.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
@@ -923,10 +903,10 @@
         </pluginManagement>
     </build>
     <properties>
-        <carbon.analytics.version>3.0.58</carbon.analytics.version>
+        <carbon.analytics.version>3.0.59-SNAPSHOT</carbon.analytics.version>
         <siddhi.version>5.1.22</siddhi.version>
 
-        <carbon.analytics-common.version>6.1.58</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.59-SNAPSHOT</carbon.analytics-common.version>
         <!-- Maven plugins -->
         <!--Bundle Plugin - Overridden from parent due to a bug in latest version related to capability providers-->
         <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
@@ -955,7 +935,7 @@
         <carbon.deployment.version>5.2.2</carbon.deployment.version>
 
         <carbon.datasources.version>1.1.11</carbon.datasources.version>
-        <carbon.metrics.version>2.3.13</carbon.metrics.version>
+        <carbon.metrics.version>2.3.15</carbon.metrics.version>
         <carbon.jndi.version>1.0.5</carbon.jndi.version>
 
         <carbon.cache.version>1.1.3</carbon.cache.version>
@@ -1016,8 +996,7 @@
         <common.collections4.version>4.0</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.8.4</msf4j.version>
-        <com.fasterxml.jackson.core.version>2.8.9</com.fasterxml.jackson.core.version>
+        <msf4j.version>2.8.5-SNAPSHOT</msf4j.version>
         <io.swagger.version>1.5.22</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
         <pax.logging.api.version>2.1.0-wso2v3</pax.logging.api.version>
@@ -1037,7 +1016,7 @@
         <project.scm.id>scm-server</project.scm.id>
 
         <!--Siddhi Extension Versions-->
-        <siddhi.execution.math.version>5.0.5</siddhi.execution.math.version>
+        <siddhi.execution.math.version>5.0.6-SNAPSHOT</siddhi.execution.math.version>
         <siddhi.execution.regex.version>5.0.7</siddhi.execution.regex.version>
         <siddhi.execution.string.version>5.0.12</siddhi.execution.string.version>
         <siddhi.execution.time.version>5.0.8</siddhi.execution.time.version>
@@ -1057,9 +1036,9 @@
         <siddhi.io.rabbitmq.version>3.0.7</siddhi.io.rabbitmq.version>
         <siddhi.io.mqtt.version>3.0.1</siddhi.io.mqtt.version>
         <siddhi.io.kafka.version>5.0.16</siddhi.io.kafka.version>
-        <siddhi.io.http.version>2.3.4</siddhi.io.http.version>
+        <siddhi.io.http.version>2.3.5-SNAPSHOT</siddhi.io.http.version>
         <siddhi.io.sqs.version>3.0.1</siddhi.io.sqs.version>
-        <siddhi.io.websocket.version>3.0.2</siddhi.io.websocket.version>
+        <siddhi.io.websocket.version>3.0.3-SNAPSHOT</siddhi.io.websocket.version>
         <siddhi.io.cdc.version>2.0.12</siddhi.io.cdc.version>
         <siddhi.io.prometheus.version>2.1.3</siddhi.io.prometheus.version>
         <siddhi.io.nats.version>2.0.15</siddhi.io.nats.version>
@@ -1070,15 +1049,15 @@
         <siddhi.io.gcs.version>1.0.2</siddhi.io.gcs.version>
         <siddhi.io.s3.version>1.0.4</siddhi.io.s3.version>
 
-        <siddhi.map.json.version>5.2.2</siddhi.map.json.version>
-        <siddhi.map.avro.version>2.2.2</siddhi.map.avro.version>
+        <siddhi.map.json.version>5.2.3-SNAPSHOT</siddhi.map.json.version>
+        <siddhi.map.avro.version>2.2.3-SNAPSHOT</siddhi.map.avro.version>
         <siddhi.map.binary.version>2.1.1</siddhi.map.binary.version>
         <siddhi.map.text.version>2.1.1</siddhi.map.text.version>
         <siddhi.map.xml.version>5.2.2</siddhi.map.xml.version>
         <siddhi.map.keyvalue.version>2.1.2</siddhi.map.keyvalue.version>
         <siddhi.map.csv.version>2.1.1</siddhi.map.csv.version>
 
-        <siddhi.store.mongodb.version>2.1.2</siddhi.store.mongodb.version>
+        <siddhi.store.mongodb.version>2.1.3-SNAPSHOT</siddhi.store.mongodb.version>
         <siddhi.store.solr.version>2.0.0</siddhi.store.solr.version>
         <siddhi.store.rdbms.version>7.0.14</siddhi.store.rdbms.version>
         <siddhi.store.hbase.version>5.0.0</siddhi.store.hbase.version>


### PR DESCRIPTION
```diff
- DO NOT MERGE Until the following are released, and the versions are bumped:
- carbon-analytics
- carbon-analytics-common
- msf4j
- siddhi execution math
- siddhi io http
- siddhi io websocket
- siddhi map json
- siddhi map avro
- siddhi store mongodb
```

## Purpose
> $subject