### PR TITLE
Upgrade msf4j version to bump the netty components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -996,7 +996,7 @@
         <common.collections4.version>4.0</common.collections4.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.8.5</msf4j.version>
+        <msf4j.version>2.8.6</msf4j.version>
         <io.swagger.version>1.5.22</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
         <pax.logging.api.version>2.1.0-wso2v3</pax.logging.api.version>
@@ -1078,7 +1078,7 @@
         <org.snakeyaml.version>1.17</org.snakeyaml.version>
         <mysql.con.version>6.0.5</mysql.con.version>
         <googlecode.json-simple.version>1.1.wso2v1</googlecode.json-simple.version>
-        <io.netty.version>4.1.74.Final</io.netty.version>
+        <io.netty.version>4.1.81.Final</io.netty.version>
         <log4j.version>2.17.1</log4j.version>
         <commons-codec.wso2.version>1.3.0.wso2v1</commons-codec.wso2.version>
 


### PR DESCRIPTION
## Purpose
When we start a SI tooling 4.1.0 pack on aarch64 architecture, an error is thrown due to an issue in netty components below version `4.1.79.Final`. Since MSF4J is packing the netty components to SI and SI tooling, This PR will upgrade the msf4j version to `2.8.6` which contains the latest(`4.1.81.Final`) netty components.

Fixes https://github.com/wso2/api-manager/issues/723