### PR TITLE
Remove siddhi-store-elasticsearch dependency

### DIFF
--- a/modules/distribution/carbon-home/LICENSE.txt
+++ b/modules/distribution/carbon-home/LICENSE.txt
@@ -219,7 +219,6 @@ siddhi-io-tcp-3.0.6.jar                                                         
 siddhi-execution-streamingml-2.0.4.jar                                                              bundle         apache2
 siddhi-io-googlepubsub-2.0.3.jar                                                                    bundle         apache2
 siddhi-execution-env-2.0.0.jar                                                                      bundle         apache2
-siddhi-store-elasticsearch-3.2.2.jar                                                                bundle         apache2
 siddhi-map-xml-5.2.2.jar                                                                            bundle         apache2
 siddhi-map-json-5.2.3.jar                                                                           bundle         apache2
 siddhi-store-redis-3.1.3.jar                                                                        bundle         apache2

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -556,12 +556,6 @@
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>io.siddhi.extension.store.elasticsearch</groupId>
-                                    <artifactId>siddhi-store-elasticsearch</artifactId>
-                                    <version>${siddhi.store.elasticsearch.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>io.siddhi.extension.io.sqs</groupId>
                                     <artifactId>siddhi-io-sqs</artifactId>
                                     <version>${siddhi.io.sqs.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1050,7 +1050,6 @@
         <siddhi.store.rdbms.version>7.0.17</siddhi.store.rdbms.version>
         <siddhi.store.cassandra.version>2.0.0</siddhi.store.cassandra.version>
         <siddhi.store.redis.version>3.1.3</siddhi.store.redis.version>
-        <siddhi.store.elasticsearch.version>3.2.2</siddhi.store.elasticsearch.version>
 
         <siddhi.script.js.version>5.0.4</siddhi.script.js.version>
 


### PR DESCRIPTION
## Purpose
This PR removes the siddhi-store-elasticsearch dependency from the SI Tooling distribution.