### PR TITLE
Disable additional validation of ZIP64 extra fields

### DIFF
--- a/modules/distribution/carbon-home/runtime/server/carbon.bat
+++ b/modules/distribution/carbon-home/runtime/server/carbon.bat
@@ -181,6 +181,8 @@ if %jver% GEQ 11000 set JAVA_VER_BASED_OPTS="--add-opens=java.base/sun.reflect.a
 set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%RUNTIME_HOME%\logs\heap-dump.hprof" -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% %JAVA_VER_BASED_OPTS% -Dcarbon.home="%CARBON_HOME%" -Dwso2.runtime.path="%RUNTIME_HOME%" -Dwso2.runtime="%RUNTIME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%CARBON_HOME%\tmp" -Dcarbon.classpath=%CARBON_CLASSPATH% -Dfile.encoding=UTF8  -Djavax.net.ssl.keyStore="%CARBON_HOME%\resources\security\wso2carbon.jks" -Djavax.net.ssl.keyStorePassword="wso2carbon" -Djavax.net.ssl.trustStore="%CARBON_HOME%\resources\security\client-truststore.jks" -Djavax.net.ssl.trustStorePassword="wso2carbon"
 set CMD_LINE_ARGS=%CMD_LINE_ARGS% -Dorg.ops4j.pax.logging.logReaderEnabled="false"
 set CMD_LINE_ARGS=%CMD_LINE_ARGS% -Dorg.ops4j.pax.logging.eventAdminEnabled="false"
+set CMD_LINE_ARGS=%CMD_LINE_ARGS% -Djdk.util.zip.disableZip64ExtraFieldValidation="true"
+set CMD_LINE_ARGS=%CMD_LINE_ARGS% -Djdk.nio.zipfs.allowDotZipEntry="true"
 
 :runJava
 echo JAVA_HOME environment variable is set to %JAVA_HOME%

--- a/modules/distribution/carbon-home/runtime/server/carbon.sh
+++ b/modules/distribution/carbon-home/runtime/server/carbon.sh
@@ -303,6 +303,8 @@ do
     -Djavax.net.ssl.trustStorePassword="wso2carbon" \
     -Dorg.ops4j.pax.logging.logReaderEnabled=false \
     -Dorg.ops4j.pax.logging.eventAdminEnabled=false \
+    -Djdk.util.zip.disableZip64ExtraFieldValidation=true \
+    -Djdk.nio.zipfs.allowDotZipEntry=true \
     org.wso2.carbon.launcher.Main $*
     status=$?
 done


### PR DESCRIPTION
## Purpose

- Disabled additional validation of ZIP64 extra fields when starting the pack
- Fixed https://github.com/wso2/api-manager/issues/2252

## Approach
- Added    ` -Djdk.util.zip.disableZip64ExtraFieldValidation=true 
    -Djdk.nio.zipfs.allowDotZipEntry=true` system parameters.