### PR TITLE
Remove execution env from the dependencies

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -378,12 +378,6 @@
                                     <type>jar</type>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.wso2.extension.siddhi.execution.env</groupId>
-                                    <artifactId>siddhi-execution-env</artifactId>
-                                    <version>${siddhi.execution.env.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>io.siddhi.extension.execution.json</groupId>
                                     <artifactId>siddhi-execution-json</artifactId>
                                     <version>${siddhi.execution.json.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1033,7 +1033,6 @@
         <siddhi.execution.unitconversion.version>2.0.2</siddhi.execution.unitconversion.version>
         <siddhi.execution.streamingml.version>2.0.6</siddhi.execution.streamingml.version>
         <siddhi.execution.unique.version>5.0.5</siddhi.execution.unique.version>
-        <siddhi.execution.env.version>2.0.1</siddhi.execution.env.version>
 
         <siddhi.io.file.version>2.0.25</siddhi.io.file.version>
         <siddhi.io.tcp.version>3.0.6</siddhi.io.tcp.version>


### PR DESCRIPTION
$subject
This is a temporary removal. This dependency is not in the server as well. This should ideally be in both