### PR TITLE
Remove carbon analytics feature

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -985,11 +985,6 @@
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
 
-                                <feature>
-                                    <id>org.wso2.carbon.streaming.integrator.core.feature</id>
-                                    <version>${carbon.analytics.version}</version>
-                                </feature>
-
                                 <!--simulator feature-->
                                 <feature>
                                     <id>org.wso2.carbon.event.simulator.core.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -905,7 +905,7 @@
         </pluginManagement>
     </build>
     <properties>
-        <carbon.analytics.version>3.0.72</carbon.analytics.version>
+        <carbon.analytics.version>3.0.73</carbon.analytics.version>
         <siddhi.version>5.1.31</siddhi.version>
 
         <carbon.analytics-common.version>6.1.69</carbon.analytics-common.version>


### PR DESCRIPTION
This was used to get the json-path libraries but this gives a OOM sometime. Thus json-path libraries are now provided in the siddhi.editor.core